### PR TITLE
Replace bot direct access to DB with API interaction

### DIFF
--- a/borgbot/Cargo.toml
+++ b/borgbot/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.68"
-chrono = "0.4.24"
-entity = { path = "../entity" }
-sea-orm = { version = "0.11.3", features = ["sqlx-postgres", "runtime-actix-rustls"] }
+reqwest = { version = "0.11.18", features = ["json"] }
 tokio = { version = "1.28.1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"] }

--- a/borgbot/src/stream.rs
+++ b/borgbot/src/stream.rs
@@ -57,7 +57,7 @@ async fn register_user() -> Result<(), reqwest::Error> {
     map.insert("body", "json");
 
     let client = reqwest::Client::new();
-    let register_endpoint = format!("{}/register", get_api_url());
+    let register_endpoint = format!("{}/users", get_api_url());
     client.post(register_endpoint).json(&map).send().await?;
 
     Ok(())

--- a/borgbot/src/stream.rs
+++ b/borgbot/src/stream.rs
@@ -1,31 +1,9 @@
-use std::time::Duration;
-
-use chrono::Utc;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, NotSet};
-use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
-use tracing::log;
+use std::collections::HashMap;
+use tracing::info;
 use tracing::{event, Level};
 use twitch_irc::login::StaticLoginCredentials;
 use twitch_irc::message::ServerMessage::Privmsg;
 use twitch_irc::{ClientConfig, SecureTCPTransport, TwitchIRCClient};
-use uuid::Uuid;
-
-/// Function for making a connection to the database, automatically configured and pooled
-pub(crate) async fn connect() -> Result<DatabaseConnection, DbErr> {
-    let db_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    let mut opt = ConnectOptions::new(db_url);
-    opt.max_connections(100)
-        .min_connections(5)
-        .connect_timeout(Duration::from_secs(8))
-        .acquire_timeout(Duration::from_secs(8))
-        .idle_timeout(Duration::from_secs(8))
-        .max_lifetime(Duration::from_secs(8))
-        .sqlx_logging(true)
-        .sqlx_logging_level(log::LevelFilter::Info);
-
-    Database::connect(opt).await
-}
 
 pub(crate) async fn connect_to_twitch_chat(streamer: String) {
     // initializes the bot configuration
@@ -50,21 +28,7 @@ pub(crate) async fn connect_to_twitch_chat(streamer: String) {
                     );
                     match msg.message_text {
                         _text if msg.message_text.to_lowercase().contains("!register") => {
-                            let new_viewer = entity::viewer::ActiveModel {
-                                id: Set(Uuid::new_v4()),
-                                username: Set(msg.sender.name),
-                                created_at: Set(Utc::now()),
-                                updated_at: Set(Utc::now()),
-                            };
-                            let db = connect().await.unwrap();
-                            match new_viewer.insert(&db).await {
-                                Ok(_) => {
-                                    event!(Level::INFO, "viewer registered");
-                                }
-                                Err(e) => {
-                                    event!(Level::ERROR, "viewer registration failed: {:?}", e);
-                                }
-                            };
+                            info!("New viewer attempting to register {}", msg.sender.name);
                         }
                         _ => {}
                     }
@@ -81,19 +45,20 @@ pub(crate) async fn connect_to_twitch_chat(streamer: String) {
     join_handle.await.unwrap();
 }
 
-#[derive(Debug)]
-struct CustomTokenStorage {}
+/// Utility function for grabbing the API_URL from the environment
+fn get_api_url() -> String {
+    std::env::var("API_URL").expect("API_URL must be set")
+}
 
-// #[async_trait]
-// impl TokenStorage for CustomTokenStorage {
-//     type LoadError = ();
-//     type UpdateError = ();
-//
-//     async fn load_token(&self) -> Result<Option<String>, Self::LoadError> {
-//         Ok(None)
-//     }
-//
-//     async fn update_token(&self, _: &str) -> Result<(), Self::UpdateError> {
-//         Ok(())
-//     }
-// }
+/// Utility function for sending a registration request to the borgapi
+async fn register_user() -> Result<(), reqwest::Error> {
+    let mut map = HashMap::new();
+    map.insert("lang", "rust");
+    map.insert("body", "json");
+
+    let client = reqwest::Client::new();
+    let register_endpoint = format!("{}/register", get_api_url());
+    client.post(register_endpoint).json(&map).send().await?;
+
+    Ok(())
+}

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
+chrono = "0.4.24"
 sea-orm = { version = "^0" }
 uuid = { version = "1.3.3", features = ["v4", "fast-rng", "macro-diagnostics"] }

--- a/entity/src/viewer.rs
+++ b/entity/src/viewer.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
 
@@ -19,6 +20,8 @@ impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
         Self {
             id: Set(Uuid::new_v4()),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
             ..ActiveModelTrait::default()
         }
     }


### PR DESCRIPTION
A "fix" for #2, mostly just by having the registration (db insert) happen via the API instead of the bot directly